### PR TITLE
Works when running pyCharms tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.DS_Store
+
+.idea/

--- a/Model/__init__.py
+++ b/Model/__init__.py
@@ -1,0 +1,1 @@
+# init file

--- a/Model/rssticker.py
+++ b/Model/rssticker.py
@@ -1,0 +1,5 @@
+import feedparser
+
+class RssModel:
+    def get_rss_feeds(feed):
+        return feedparser.parse(feed)

--- a/Tests/test_model.py
+++ b/Tests/test_model.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import patch
+from Model.rssticker import RssModel
+
+
+class TestRssTicker(unittest.TestCase):
+    def setUp(self):
+        self.rss = RssModel()
+        pass
+
+    def test_get_rss_feeds(self):
+        with patch.object(RssModel, 'get_rss_feeds', return_value={'feed', 'entries'}) as mock_method:
+            values = self.rss.get_rss_feeds()
+            assert 'feed' in values
+            assert 'entries' in values


### PR DESCRIPTION
This works in PyCharm but has an issue with feed parser import while running it via command line. https://stackoverflow.com/questions/34417521/how-to-mock-imported-library-methods-with-unittest-mock-in-python-3-5